### PR TITLE
Allow placing of lua files in a subfolder

### DIFF
--- a/dat2lua.lua
+++ b/dat2lua.lua
@@ -1,5 +1,8 @@
 assert("Lua 5.3" == _VERSION)
 
+local _,_, MY_PATH= string.find( arg[0], "(.+[/\\]).-" )
+assert(MY_PATH)
+
 local in_file = assert(arg[1], "no input")
 local out_file = arg[2]
 
@@ -160,13 +163,13 @@ r = assert(io.open(in_file, "rb"))
 assert(6 == uint8())
 
 -- generate types dictionary
-local d = dofile("dict_types.lua")
+local d = dofile(MY_PATH.."dict_types.lua")
 for i = 1, #d, 2 do
     dict_t[d[i]] = d[i+1]
 end
 
 -- generate external dictionary
-d = dofile("dict_ext.lua")
+d = dofile(MY_PATH.."dict_ext.lua")
 for i = 1, #d, 2 do
     dict_e[d[i]] = d[i+1]
 end

--- a/dat2txt.lua
+++ b/dat2txt.lua
@@ -1,5 +1,8 @@
 assert("Lua 5.3" == _VERSION)
 
+local _,_, MY_PATH= string.find( arg[0], "(.+[/\\]).-" )
+assert(MY_PATH)
+
 local in_file = assert(arg[1], "no input")
 local out_path = arg[2] or "."
 
@@ -114,13 +117,13 @@ r = assert(io.open(in_file, "rb"))
 assert(6 == uint8())
 
 -- generate types dictionary
-local d = dofile("dict_types.lua")
+local d = dofile(MY_PATH.."dict_types.lua")
 for i = 1, #d, 2 do
     dict_t[d[i]] = d[i+1]
 end
 
 -- generate external dictionary
-local d = dofile("dict_ext.lua")
+local d = dofile(MY_PATH.."dict_ext.lua")
 for i = 1, #d, 2 do
     dict_e[d[i]] = d[i+1]
 end

--- a/dat2xml.lua
+++ b/dat2xml.lua
@@ -1,5 +1,8 @@
 assert("Lua 5.3" == _VERSION)
 
+local _,_, MY_PATH= string.find( arg[0], "(.+[/\\]).-" )
+assert(MY_PATH)
+
 local in_file = assert(arg[1], "no input")
 local out_path = arg[2] or "."
 
@@ -105,13 +108,13 @@ r = assert(io.open(in_file, "rb"))
 assert(6 == uint8())
 
 -- generate types dictionary
-local d = dofile("dict_types.lua")
+local d = dofile(MY_PATH.."dict_types.lua")
 for i = 1, #d, 2 do
     dict_t[d[i]] = d[i+1]
 end
 
 -- generate external dictionary
-local d = dofile("dict_ext.lua")
+local d = dofile(MY_PATH.."dict_ext.lua")
 for i = 1, #d, 2 do
     dict_e[d[i]] = d[i+1]
 end

--- a/lua2dat.lua
+++ b/lua2dat.lua
@@ -1,5 +1,8 @@
 assert("Lua 5.3" == _VERSION)
 
+local _,_, MY_PATH= string.find( arg[0], "(.+[/\\]).-" )
+assert(MY_PATH)
+
 local in_file = assert(arg[1], "no input")
 local out_file = arg[2] or "OUT.DAT"
 
@@ -86,13 +89,13 @@ end
 -------------------------------------------------------------------------------
 
 -- generate types dictionary
-local d = dofile("dict_types.lua")
+local d = dofile(MY_PATH.."dict_types.lua")
 for i = 1, #d, 2 do
     dict_t[d[i+1]] = d[i]
 end
 
 -- generate external dictionary
-d = dofile("dict_ext.lua")
+d = dofile(MY_PATH.."dict_ext.lua")
 for i = 1, #d, 2 do
     dict_e[d[i+1]] = d[i]
 end


### PR DESCRIPTION
Add retrieval of directory the lua script is executing from.
Use the retrieved directory in dofile calls to allow scripts to be placed in a different directory than they are getting called from.
